### PR TITLE
Update docs and examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,8 +25,8 @@ In order to implement tracing in your system (for all the requests), add the fol
 
 .. code-block:: python
 
-    from opentracing_tornado.scope_managers import TornadoScopeManager
     import tornado_opentracing
+    from tornado_opentracing.scope_managers import TornadoScopeManager
 
     # Create your opentracing tracer using TornadoScopeManager for active Span handling.
     tracer = SomeOpenTracingTracer(scope_manager=TornadoScopeManager())
@@ -48,7 +48,7 @@ In order to implement tracing in your system (for all the requests), add the fol
         ''' Other parameters here '''
         opentracing_tracer_callable='opentracing.mocktracer.MockTracer',
         opentracing_tracer_parameters={
-            'scope_manager': opentracing.scope_managers.TornadoScopeManager(),
+            'scope_manager': tornado_opentracing.scope_managers.TornadoScopeManager(),
         },
     )
 
@@ -115,11 +115,11 @@ For applications tracing individual requests, or using only the http client (no 
 Active Span handling
 ====================
 
-For active ``Span`` handling and propagation, your ``Tracer`` should use ``opentracing.scope_managers.tornado.TornadoScopeManager``. Tracing both all requests and individual requests will set up a proper stack context automatically, and the active ``Span`` will be propagated from parent coroutines to their children. In any other case, code needs to be run under ``tracer_stack_context()`` explicitly:
+For active ``Span`` handling and propagation, your ``Tracer`` should use ``tornado_opentracing.scope_managers.TornadoScopeManager``. Tracing both all requests and individual requests will set up a proper stack context automatically, and the active ``Span`` will be propagated from parent coroutines to their children. In any other case, code needs to be run under ``tracer_stack_context()`` explicitly:
 
 .. code-block:: python
 
-    from opentracing.scope_managers.tornado import tracer_stack_context
+    from tornado_opentracing.scope_managers import tracer_stack_context
 
     with tracer_stack_context():
         ioloop.IOLoop.current().run_sync(main_func)

--- a/examples/client-server/main.py
+++ b/examples/client-server/main.py
@@ -4,8 +4,8 @@ from tornado.web import Application, RequestHandler
 from tornado import gen
 
 import opentracing
-from opentracing.scope_managers.tornado import TornadoScopeManager
 import tornado_opentracing
+from tornado_opentracing.scope_managers import TornadoScopeManager
 
 
 def client_start_span_cb(span, request):

--- a/examples/simple/main.py
+++ b/examples/simple/main.py
@@ -3,8 +3,8 @@ from tornado.web import Application, RequestHandler
 from tornado import gen
 
 import opentracing
-from opentracing.scope_managers.tornado import TornadoScopeManager
 import tornado_opentracing
+from tornado_opentracing.scope_managers import TornadoScopeManager 
 
 
 tornado_opentracing.init_tracing()

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -2,7 +2,7 @@ import sys
 
 import tornado_opentracing
 from opentracing.mocktracer import MockTracer
-from tornado_opentracing.scope_managers import ScopeManager
+from tornado_opentracing.scope_managers import TornadoScopeManager
 
 
 if sys.version_info >= (3, 3):
@@ -11,4 +11,4 @@ else:
     from ._test_case import AsyncHTTPTestCase  # noqa
 
 
-tracing = tornado_opentracing.TornadoTracing(MockTracer(ScopeManager()))
+tracing = tornado_opentracing.TornadoTracing(MockTracer(TornadoScopeManager()))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -20,7 +20,7 @@ from tornado.httpclient import HTTPRequest
 import tornado.web
 import tornado.testing
 import tornado_opentracing
-from tornado_opentracing.scope_managers import ScopeManager
+from tornado_opentracing.scope_managers import TornadoScopeManager
 from tornado_opentracing.context_managers import tornado_context
 
 from .helpers import AsyncHTTPTestCase
@@ -51,7 +51,7 @@ def make_app():
 
 class TestClient(AsyncHTTPTestCase):
     def setUp(self):
-        self.tracer = MockTracer(ScopeManager())
+        self.tracer = MockTracer(TornadoScopeManager())
         super(TestClient, self).setUp()
 
     def tearDown(self):

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -24,7 +24,7 @@ import tornado.testing
 import tornado_opentracing
 from tornado import version_info as tornado_version
 from tornado_opentracing import TornadoTracing
-from tornado_opentracing.scope_managers import ScopeManager
+from tornado_opentracing.scope_managers import TornadoScopeManager
 from tornado_opentracing.context_managers import tornado_context
 
 from .helpers import AsyncHTTPTestCase
@@ -143,7 +143,7 @@ class TestTornadoTracingBase(AsyncHTTPTestCase):
 
 class TestInitWithoutTracingObj(TestTornadoTracingBase):
     def get_app(self):
-        self.tracer = MockTracer(ScopeManager())
+        self.tracer = MockTracer(TornadoScopeManager())
         return make_app(start_span_cb=self.start_span_cb)
 
     def start_span_cb(self, span, request):
@@ -176,7 +176,7 @@ def tracer_callable(tracer):
 
 class TestInitWithTracerCallable(TestTornadoTracingBase):
     def get_app(self):
-        self.tracer = MockTracer(ScopeManager())
+        self.tracer = MockTracer(TornadoScopeManager())
         return make_app(tracer_callable=tracer_callable, tracer_parameters={
             'tracer': self.tracer,
         })
@@ -194,7 +194,7 @@ class TestInitWithTracerCallable(TestTornadoTracingBase):
 
 class TestInitWithTracerCallableStr(TestTornadoTracingBase):
     def get_app(self):
-        self.tracer = MockTracer(ScopeManager())
+        self.tracer = MockTracer(TornadoScopeManager())
         return make_app(tracer_callable='tests.test_tracing.tracer_callable',
                         tracer_parameters={
                             'tracer': self.tracer
@@ -213,7 +213,7 @@ class TestInitWithTracerCallableStr(TestTornadoTracingBase):
 
 class TestTracing(TestTornadoTracingBase):
     def get_app(self):
-        self.tracer = MockTracer(ScopeManager())
+        self.tracer = MockTracer(TornadoScopeManager())
         return make_app(self.tracer, trace_client=False)
 
     def test_simple(self):
@@ -337,7 +337,7 @@ class TestTracing(TestTornadoTracingBase):
 
 class TestNoTraceAll(TestTornadoTracingBase):
     def get_app(self):
-        self.tracer = MockTracer(ScopeManager())
+        self.tracer = MockTracer(TornadoScopeManager())
         return make_app(self.tracer, trace_all=False, trace_client=False)
 
     def test_simple(self):
@@ -350,7 +350,7 @@ class TestNoTraceAll(TestTornadoTracingBase):
 
 class TestTracedAttributes(TestTornadoTracingBase):
     def get_app(self):
-        self.tracer = MockTracer(ScopeManager())
+        self.tracer = MockTracer(TornadoScopeManager())
         return make_app(self.tracer,
                         trace_client=False,
                         traced_attributes=[
@@ -385,7 +385,7 @@ class TestStartSpanCallback(TestTornadoTracingBase):
         span.set_tag('custom-tag', 'custom-value')
 
     def get_app(self):
-        self.tracer = MockTracer(ScopeManager())
+        self.tracer = MockTracer(TornadoScopeManager())
         return make_app(self.tracer,
                         trace_client=False,
                         start_span_cb=self.start_span_cb)
@@ -413,7 +413,7 @@ class TestStartSpanCallbackException(TestTornadoTracingBase):
         raise RuntimeError('This should not happen')
 
     def get_app(self):
-        self.tracer = MockTracer(ScopeManager())
+        self.tracer = MockTracer(TornadoScopeManager())
         return make_app(self.tracer,
                         trace_client=False,
                         start_span_cb=self.start_span_cb)
@@ -429,7 +429,7 @@ class TestStartSpanCallbackException(TestTornadoTracingBase):
 
 class TestClient(TestTornadoTracingBase):
     def get_app(self):
-        self.tracer = MockTracer(ScopeManager())
+        self.tracer = MockTracer(TornadoScopeManager())
         return make_app(self.tracer,
                         trace_all=False)
 
@@ -454,7 +454,7 @@ class TestClient(TestTornadoTracingBase):
 
 class TestClientCallback(TestTornadoTracingBase):
     def get_app(self):
-        self.tracer = MockTracer(ScopeManager())
+        self.tracer = MockTracer(TornadoScopeManager())
         return make_app(self.tracer,
                         trace_all=False,
                         start_span_cb=self.start_span_cb)

--- a/tornado_opentracing/scope_managers.py
+++ b/tornado_opentracing/scope_managers.py
@@ -11,8 +11,12 @@ from tornado import version_info as tornado_version
 
 if tornado_version >= (6, 0):
     if sys.version_info >= (3, 7):
-        from opentracing.scope_managers.contextvars import ContextVarsScopeManager as ScopeManager  # noqa
+        from opentracing.scope_managers.contextvars import (
+            ContextVarsScopeManager as TornadoScopeManager  # noqa
+        )
     else:
-        from opentracing.scope_managers.asyncio import AsyncioScopeManager as ScopeManager  # noqa
+        from opentracing.scope_managers.asyncio import (
+            AsyncioScopeManager as TornadoScopeManager  # noqa
+        )
 else:
-    from opentracing.scope_managers.tornado import TornadoScopeManager as ScopeManager  # noqa
+    from opentracing.scope_managers.tornado import TornadoScopeManager  # noqa


### PR DESCRIPTION
Updated documentation and example to highlight the new universal tornado
scope manager that works with all versions.

This requires users to import the TornadoScopeManager from
`tornado_opentracing.scope_managers` instead of
`opentracing.scope_managers.tornado`. This will be mentioned in detail
in the release docs.

We'll also submit a PR to python-opentracing and patch it to export the
correct scope manager based on Tornado and Python version being used so
the above change will be unnecesary.