### PR TITLE
Replace OpenTracing error logs with SignalFx tags

### DIFF
--- a/tests/test_decorated.py
+++ b/tests/test_decorated.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 import tornado.gen
 import tornado.web
 import tornado.testing
@@ -30,6 +32,11 @@ from .helpers.markers import (
     skip_generator_contextvars_on_py34,
     skip_no_async_await,
 )
+
+
+error_object = "<class 'ValueError'>"
+if sys.version_info.major == 2:
+    error_object = "<type 'exceptions.ValueError'>"
 
 
 class MainHandler(tornado.web.RequestHandler):
@@ -156,14 +163,12 @@ class TestDecorated(tornado.testing.AsyncHTTPTestCase):
 
         tags = spans[0].tags
         self.assertEqual(tags.get('error', None), True)
-
-        logs = spans[0].logs
-        self.assertEqual(len(logs), 1)
-        self.assertEqual(logs[0].key_values.get('event', None),
-                         'error')
-        self.assertTrue(isinstance(
-            logs[0].key_values.get('error.object', None), ValueError
-        ))
+        self.assertEqual(tags.get('sfx.error.kind', None), 'ValueError')
+        self.assertEqual(tags.get('sfx.error.object', None), error_object)
+        self.assertEqual(tags.get('sfx.error.message', None), 'invalid value')
+        assert 'sfx.error.stack' in tags
+        assert 'invalid value' in tags['sfx.error.stack']
+        assert len(tags['sfx.error.stack']) > 50
 
     @skip_generator_contextvars_on_tornado6
     @skip_generator_contextvars_on_py34
@@ -198,14 +203,12 @@ class TestDecorated(tornado.testing.AsyncHTTPTestCase):
 
         tags = spans[0].tags
         self.assertEqual(tags.get('error', None), True)
-
-        logs = spans[0].logs
-        self.assertEqual(len(logs), 1)
-        self.assertEqual(logs[0].key_values.get('event', None),
-                         'error')
-        self.assertTrue(isinstance(
-            logs[0].key_values.get('error.object', None), ValueError
-        ))
+        self.assertEqual(tags.get('sfx.error.kind', None), 'ValueError')
+        self.assertEqual(tags.get('sfx.error.object', None), error_object)
+        self.assertEqual(tags.get('sfx.error.message', None), 'invalid value')
+        assert 'sfx.error.stack' in tags
+        assert 'invalid value' in tags['sfx.error.stack']
+        assert len(tags['sfx.error.stack']) > 50
 
     @skip_generator_contextvars_on_tornado6
     @skip_generator_contextvars_on_py34
@@ -271,14 +274,12 @@ class TestDecorated(tornado.testing.AsyncHTTPTestCase):
 
         tags = spans[0].tags
         self.assertEqual(tags.get('error', None), True)
-
-        logs = spans[0].logs
-        self.assertEqual(len(logs), 1)
-        self.assertEqual(logs[0].key_values.get('event', None),
-                         'error')
-        self.assertTrue(isinstance(
-            logs[0].key_values.get('error.object', None), ValueError
-        ))
+        self.assertEqual(tags.get('sfx.error.kind', None), 'ValueError')
+        self.assertEqual(tags.get('sfx.error.object', None), error_object)
+        self.assertEqual(tags.get('sfx.error.message', None), 'invalid value')
+        assert 'sfx.error.stack' in tags
+        assert 'invalid value' in tags['sfx.error.stack']
+        assert len(tags['sfx.error.stack']) > 50
 
     @skip_no_async_await
     def test_async_scope(self):

--- a/tornado_opentracing/_tracing.py
+++ b/tornado_opentracing/_tracing.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import functools
+import sys
+import traceback
 import wrapt
 
 import opentracing
@@ -92,7 +94,9 @@ class BaseTornadoTracing(object):
                     result = wrapped(*args, **kwargs)
                     self._handle_wrapped_result(handler, result)
                 except Exception as exc:
-                    self._finish_tracing(handler, error=exc)
+                    self._finish_tracing(
+                        handler, error=exc, tb=sys.exc_info()[2]
+                    )
                     raise
 
             return result
@@ -104,8 +108,11 @@ class BaseTornadoTracing(object):
         return full_class_name.rsplit('.')[-1]  # package-less name.
 
     def _finish_tracing_callback(self, future, handler):
-        error = future.exception()
-        self._finish_tracing(handler, error=error)
+        exc_info = future.exc_info()
+        if exc_info:
+            self._finish_tracing(handler, error=exc_info[1], tb=exc_info[2])
+            return
+        self._finish_tracing(handler)
 
     def _apply_tracing(self, handler, attributes):
         """
@@ -147,7 +154,7 @@ class BaseTornadoTracing(object):
 
         return scope
 
-    def _finish_tracing(self, handler, error=None):
+    def _finish_tracing(self, handler, error=None, tb=None):
         scope = getattr(handler.request, SCOPE_ATTR, None)
         if scope is None:
             return
@@ -156,10 +163,14 @@ class BaseTornadoTracing(object):
 
         if error is not None:
             scope.span.set_tag(tags.ERROR, True)
-            scope.span.log_kv({
-                'event': tags.ERROR,
-                'error.object': error,
-            })
+            scope.span.set_tag('sfx.error.message', str(error))
+            scope.span.set_tag('sfx.error.object', str(error.__class__))
+            scope.span.set_tag('sfx.error.kind', error.__class__.__name__)
+            if tb:
+                scope.span.set_tag(
+                    'sfx.error.stack',
+                    ''.join(traceback.format_tb(tb))
+                )
         else:
             scope.span.set_tag(tags.HTTP_STATUS_CODE, handler.get_status())
 

--- a/tornado_opentracing/_tracing_async.py
+++ b/tornado_opentracing/_tracing_async.py
@@ -8,6 +8,7 @@ such as linters that it should be only be taken into account
 for Python3.5 and above.
 """
 
+import sys
 import inspect
 import functools
 
@@ -55,7 +56,9 @@ class AsyncTornadoTracing(BaseTornadoTracing):
                     tracing._handle_wrapped_result(handler, result)
 
                 except Exception as exc:
-                    tracing._finish_tracing(handler, error=exc)
+                    tracing._finish_tracing(
+                        handler, error=exc, tb=sys.exc_info()[2]
+                    )
                     raise
 
             def __get__(self, instance, owner):

--- a/tornado_opentracing/handlers.py
+++ b/tornado_opentracing/handlers.py
@@ -57,12 +57,15 @@ def log_exception(func, handler, args, kwargs):
     is not handled in the user code.
     """
     # safe-guard: expected arguments -> log_exception(self, typ, value, tb)
-    value = args[1] if len(args) == 3 else None
-    if value is None:
+    error = tb = None
+    if len(args) == 3:
+        _, error, tb = args
+
+    if error is None:
         return func(*args, **kwargs)
 
     tracing = handler.settings.get('opentracing_tracing')
-    if not isinstance(value, HTTPError) or 500 <= value.status_code <= 599:
-        tracing._finish_tracing(handler, error=value)
+    if not isinstance(error, HTTPError) or 500 <= error.status_code <= 599:
+        tracing._finish_tracing(handler, error=error, tb=tb)
 
     return func(*args, **kwargs)


### PR DESCRIPTION
This PR changes how errors are recorded on spans. It uses the new
SignalFx semantic convention and records the errors as attributes
instead of logs.